### PR TITLE
[Documentation] Fix OS default config file path

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -4,7 +4,7 @@ Zellij will look for a file `config.yaml` in the default configuration location 
 
 **Linux**: `/home/alice/.config/zellij`
 
-**Mac**: `/Users/Alice/Library/Application Support/com.Zellij-Contributors.zellij`
+**Mac**: `/Users/Alice/Library/Application Support/org.Zellij-Contributors.Zellij`
 
 To ignore the default config file location:
 


### PR DESCRIPTION
Having just installed Zellij via cargo, I noticed that the documentation's path to the OS X file differs from what is actually created by the application. I have `/Users/joshrotenberg/Library/Application\ Support/org.Zellij-Contributors.Zellij`; `org` instead of `com`, and the trailing `Zellij` is capitalized.

This is on Big Sur 11.2.3 